### PR TITLE
Update main.m

### DIFF
--- a/Code/main.m
+++ b/Code/main.m
@@ -108,7 +108,7 @@ function ReadCalKitObj_Callback(hObject, eventdata, handles)%#ok
                     DisbaleCalResult(handles,'newly defined CalKit');
                 end
                 % Activate the Start button if possible
-                if get(handles.RefTypeObj,'SelectedObject')
+                if ~isempty(get(handles.RefTypeObj,'SelectedObject'))
                     set(handles.StartCalObj,'enable','on')
                 else
                     set(handles.StartCalObj,'enable','off')


### PR DESCRIPTION
get(handles.RefTypeObj,'SelectedObject') does not return a logical value.
Solve matlab error "Conversion to logical from matlab.graphics.GraphicsPlaceholder is not possible." on recent Matlab version.
Tested on R2015b and R2016a.
